### PR TITLE
Fix for validator error "Element style is missing required attribute scoped"

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -2,7 +2,7 @@
 // Colour options 
 $color_option = theme_get_setting('clf_colour_option');
 if (theme_get_setting('colourpicker')) {
-print '<style media="screen">';
+print '<style scoped media="screen">';
 print "/* Header Option Overrides */
 div#ubc7-unit { background: #" . theme_get_setting('colourpicker') . "  !important;
 box-shadow: inset 0px -10px 10px -10px #333333;


### PR DESCRIPTION
Style tags in HTML5 require the scoped attribute if they are used outside the Head element.  This makes the style apply to the parent element which is fine in our case as its the body element.
http://www.w3schools.com/tags/tag_style.asp
