### PR TITLE
Button performance improvement

### DIFF
--- a/template.php
+++ b/template.php
@@ -694,14 +694,15 @@ function megatron_form_element_label(&$variables) {
 /** BUTTONS
 ---------------------------------------------------------- */
 
-/** Preprocessor for theme('button').
----------------------------------------------------------- */
-function megatron_preprocess_button(&$vars) {
-  $vars['element']['#attributes']['class'][] = 'btn';
-
-  if (isset($vars['element']['#value'])) {
-    $classes = array(
-      //specifics
+/**
+ * Implements hook_preprocess_button().
+ */
+function megatron_preprocess_button(&$variables) {
+  // Static storage of button class mapping to avoid excessive t() calls.
+  static $button_classes;
+  if (!isset($button_classes)) {
+    $button_classes = array(
+      // Specific buttons first to be caught first in the loop below.
       t('Save and add') => 'btn-info',
       t('Add another item') => 'btn-info',
       t('Add effect') => 'btn-primary',
@@ -709,7 +710,7 @@ function megatron_preprocess_button(&$vars) {
       t('Update style') => 'btn-primary',
       t('Download feature') => 'btn-primary',
 
-      //generals
+      // General buttons.
       t('Save') => 'btn-primary',
       t('Apply') => 'btn-primary',
       t('Create') => 'btn-primary',
@@ -725,9 +726,13 @@ function megatron_preprocess_button(&$vars) {
       t('Delete') => 'btn-danger',
       t('Remove') => 'btn-danger',
     );
-    foreach ($classes as $search => $class) {
-      if (strpos($vars['element']['#value'], $search) !== FALSE) {
-        $vars['element']['#attributes']['class'][] = $class;
+  }
+  $variables['element']['#attributes']['class'][] = 'btn';
+
+  if (isset($variables['element']['#value'])) {
+    foreach ($button_classes as $search => $class) {
+      if (strpos($variables['element']['#value'], $search) !== FALSE) {
+        $variables['element']['#attributes']['class'][] = $class;
         break;
       }
     }


### PR DESCRIPTION
I was doing some performance testing and noticed that 4 calls to a button yielded 46ms due to all the t() calls that were doing the same function call each time.  Statically storing the results after the first call brings those 4 calls of `megatron_preprocess_button()` down to 0.1 ms.  This can have some nice improvements if you are rendering a lot of buttons on the page.

**Before:**
<img width="1005" alt="xhprof_view___my_cs" src="https://cloud.githubusercontent.com/assets/70129/16359978/178cdc04-3afe-11e6-821b-15ebb7002c62.png">

**After**
<img width="937" alt="xhprof_view___my_cs" src="https://cloud.githubusercontent.com/assets/70129/16359976/0723d890-3afe-11e6-909c-14dbfb09d03b.png">

