### PR TITLE
Ensure the type property exists before using it.

### DIFF
--- a/template.php
+++ b/template.php
@@ -263,10 +263,10 @@ function megatron_process_block(&$variables, $hook) {
 function megatron_preprocess_page(&$variables) {
   // Define CLF page elements in an include
   include_once 'includes/template-ubc-clf-elements.inc';
-  // Add template suggestions based on content type
-  if (isset($variables['node'])) {
+  // Add template suggestions based on content type.
+  if (isset($variables['node']->type)) {
     //$variables['theme_hook_suggestions'][] = 'page' . theme_get_setting('clf_layout') . '';
-    $variables['theme_hook_suggestions'][] = 'page__type__'. $variables['node']->type;
+    $variables['theme_hook_suggestions'][] = 'page__type__' . $variables['node']->type;
   }
 
   // Add information about the number of sidebars.


### PR DESCRIPTION
The `node` variable is filled by the `print` module on `webform` submission print pages and this hook tries to use a non existent property.

`print` module could possibly be fixed by not filling up the node variable like that but this is a much easier fix on our end.