### PR TITLE
Clean up form nested XHTML relic and remove grippie

### DIFF
--- a/template.php
+++ b/template.php
@@ -950,3 +950,30 @@ function megatron_megatron_links($variables) {
 
   return $output;
 }
+
+/**
+ * Implements template_preprocess_textarea().
+ *
+ * Hide grippie.
+ */
+function megatron_preprocess_textarea(&$variables) {
+  $variables['element']['#resizable'] = FALSE;
+}
+
+/**
+ * Implements theme_form().
+ *
+ * Removes the XHTML redundant inner div.
+ */
+function megatron_form($variables) {
+  $element = $variables['element'];
+  if (isset($element['#action'])) {
+    $element['#attributes']['action'] = drupal_strip_dangerous_protocols($element['#action']);
+  }
+  element_set_attributes($element, array('method', 'id'));
+  if (empty($element['#attributes']['accept-charset'])) {
+    $element['#attributes']['accept-charset'] = "UTF-8";
+  }
+
+  return '<form' . drupal_attributes($element['#attributes']) . '>' . $element['#children'] . '</form>';
+}


### PR DESCRIPTION
Add theme functions to clean up the form inner div tag and hide the grippie because it's in browsers by default.